### PR TITLE
Add express dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,19 @@
   "dependencies": {
     "babel-core": "^6.14.0",
     "babel-loader": "^6.2.5",
+    "css-loader": "^0.25.0",
     "express": "^4.14.0",
-    "webpack": "^1.13.2"
+    "extract-text-webpack-plugin": "^1.0.1",
+    "jquery": "^3.1.1",
+    "node-sass": "^3.10.0",
+    "react": "^15.3.2",
+    "react-dom": "^15.3.2",
+    "react-router": "^2.8.1",
+    "sass-loader": "^4.0.2",
+    "style-loader": "^0.13.1",
+    "webpack": "^1.13.2",
+    "webpack-dev-middleware": "^1.8.2",
+    "webpack-hot-middleware": "^2.12.2"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.14.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "babel-core": "^6.14.0",
     "babel-loader": "^6.2.5",
+    "express": "^4.14.0",
     "webpack": "^1.13.2"
   },
   "devDependencies": {


### PR DESCRIPTION
So that `npm install` installs all dependencies and remove the need for globally/manually installed modules.
